### PR TITLE
Duplicate version string in gemspec to avoid Bundler error

### DIFF
--- a/forme.gemspec
+++ b/forme.gemspec
@@ -1,7 +1,7 @@
 require File.expand_path("../lib/forme/version", __FILE__)
 spec = Gem::Specification.new do |s|
   s.name = 'forme'
-  s.version = Forme.version
+  s.version = Forme.version.dup
   s.platform = Gem::Platform::RUBY
   s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc", "CHANGELOG", "MIT-LICENSE"]


### PR DESCRIPTION
Bundler throws the following error when installing from head:

.../1.9.1/rubygems/version.rb:191:in `strip!': can't modify frozen string (RuntimeError)

I have added .dup to the version string in the gem spec to avoid this.
