### PR TITLE
#h: return nil if string.to_s is nil

### DIFF
--- a/lib/forme.rb
+++ b/lib/forme.rb
@@ -1213,7 +1213,7 @@ module Forme
 
     # Escape ampersands, brackets and quotes to their HTML/XML entities.
     def h(string)
-      string.to_s.gsub(ESCAPE_HTML_PATTERN){|c| ESCAPE_HTML[c] }
+      string.to_s && string.to_s.gsub(ESCAPE_HTML_PATTERN){|c| ESCAPE_HTML[c] }
     end
 
     # Join attribute values that are arrays with spaces instead of an empty


### PR DESCRIPTION
I had a problem where when my `image` field (Using CarrierWave and Sequel) was empty, this line would throw NoMethodError `gsub` on nil. I have no idea if this is common enough to merge into master.
