### PR TITLE
Add forme_i18n plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ gem 'unicorn'
 
 group :development, :test do
   gem "minitest"
+  gem "i18n"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    i18n (0.7.0)
     kgio (2.10.0)
     minitest (5.8.3)
     pg (0.18.4)
@@ -19,6 +20,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  i18n
   minitest
   pg
   roda (>= 1.2.0)
@@ -27,4 +29,4 @@ DEPENDENCIES
   unicorn
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/forme.gemspec
+++ b/forme.gemspec
@@ -29,4 +29,5 @@ END
   s.add_development_dependency "tilt"
   s.add_development_dependency "sinatra"
   s.add_development_dependency "rails"
+  s.add_development_dependency "i18n"
 end

--- a/lib/sequel/plugins/forme_i18n.rb
+++ b/lib/sequel/plugins/forme_i18n.rb
@@ -1,0 +1,58 @@
+require 'i18n'
+require 'sequel/plugins/forme'
+
+module Sequel # :nodoc:
+  module Plugins # :nodoc:
+    module Forme
+      module SequelFormI18n
+        # Checks if there's a translation for the
+        # 'models.<table_name>.<association>' key and merge it to the options
+        # with the :legend key
+        #
+        # Calls the original Sequel::Plugins::Forme::SequelForm method
+        def subform(association, opts={}, &block)
+          i18n_key = "models.#{obj.class.table_name}.#{association}"
+
+          if opts[:legend].nil? && I18n.exists?(i18n_key)
+            opts[:legend] = I18n.t(i18n_key)
+          end
+
+          super
+        end
+      end
+    end
+
+    # This Sequel plugin extends Forme usage with Sequel to support I18n
+    module FormeI18n
+      def self.apply(model)
+        model.plugin(:forme)
+        model.include(self)
+      end
+
+      module InstanceMethods
+
+        # Includes the SequelFormI18n methods on the original returned class
+        def forme_form_class(base)
+          klass = super
+          klass.include Sequel::Plugins::Forme::SequelFormI18n
+
+          klass
+        end
+
+        # Checks if there's a translation for the 'models.<table_name>.<field>'
+        # key and merge it to the options with the :label key
+        #
+        # Calls the original Sequel::Plugins::Forme method
+        def forme_input(form, field, opts)
+          i18n_key = "models.#{self.class.table_name}.#{field}"
+
+          if opts[:label].nil? && I18n.exists?(i18n_key)
+            opts[:label] = I18n.t(i18n_key)
+          end
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/spec/i18n_helper.yml
+++ b/spec/i18n_helper.yml
@@ -1,0 +1,6 @@
+en:
+  models:
+    firms:
+      clients: Clientes
+    invoices:
+      summary: Brief Description

--- a/spec/sequel_i18n_helper.rb
+++ b/spec/sequel_i18n_helper.rb
@@ -1,0 +1,39 @@
+require File.join(File.dirname(File.expand_path(__FILE__)), 'sequel_helper.rb')
+
+require 'i18n'
+I18n.load_path = [File.join(File.dirname(File.expand_path(__FILE__)), 'i18n_helper.yml')] 
+
+DB.create_table(:firms) do
+  primary_key :id
+  String :name
+end
+DB.create_table(:invoices) do
+  primary_key :id
+  foreign_key :firm_id, :firms
+  String :name
+  String :summary
+end
+DB.create_table(:clients) do
+  primary_key :id
+  foreign_key :firm_id, :firms
+  String :name
+end
+
+a = DB[:firms].insert(:name=>'a')
+b = DB[:invoices].insert(:name=>'b', :firm_id=>a, :summary=>'a brief summary')
+DB[:clients].insert(:name=>'a great client', :firm_id=>a)
+
+class Firm < Sequel::Model
+  one_to_many :invoices
+  one_to_many :clients
+end
+
+class Invoice < Sequel::Model
+  many_to_one :firm
+end
+
+class Client < Sequel::Model
+  many_to_one :firm
+end
+
+[Firm, Invoice, Client].each{|c| c.plugin :forme_i18n }

--- a/spec/sequel_i18n_plugin_spec.rb
+++ b/spec/sequel_i18n_plugin_spec.rb
@@ -1,0 +1,25 @@
+require File.join(File.dirname(File.expand_path(__FILE__)), 'spec_helper.rb')
+require File.join(File.dirname(File.expand_path(__FILE__)), 'sequel_i18n_helper.rb')
+
+describe "Forme Sequel::Model forms" do
+  before do
+    @ab = Invoice[1]
+    @b = Forme::Form.new(@ab)
+  end
+
+  it "should not change the usual label input if translation is not present" do
+    @b.input(:name).to_s.must_equal '<label>Name: <input id="invoice_name" name="invoice[name]" type="text" value="b"/></label>'
+  end
+
+  it "should use the translation for the label if present" do
+    @b.input(:summary).to_s.must_equal '<label>Brief Description: <input id="invoice_summary" name="invoice[summary]" type="text" value="a brief summary"/></label>'
+  end
+
+  it "should not change the usual legend for the subform if the translation is not present" do
+    Forme.form(Firm[1]){|f| f.subform(:invoices){ f.input(:name) }}.to_s.must_equal "<form class=\"forme firm\" method=\"post\"><input id=\"firm_invoices_attributes_0_id\" name=\"firm[invoices_attributes][0][id]\" type=\"hidden\" value=\"1\"/><fieldset class=\"inputs\"><legend>Invoice #1</legend><label>Name: <input id=\"firm_invoices_attributes_0_name\" name=\"firm[invoices_attributes][0][name]\" type=\"text\" value=\"b\"/></label></fieldset></form>"
+  end
+
+  it "should use the translation for the legend on the subform if present" do
+    Forme.form(Firm[1]){|f| f.subform(:clients){ f.input(:name) }}.to_s.must_equal "<form class=\"forme firm\" method=\"post\"><input id=\"firm_clients_attributes_0_id\" name=\"firm[clients_attributes][0][id]\" type=\"hidden\" value=\"1\"/><fieldset class=\"inputs\"><legend>Clientes</legend><label>Name: <input id=\"firm_clients_attributes_0_name\" name=\"firm[clients_attributes][0][name]\" type=\"text\" value=\"a great client\"/></label></fieldset></form>"
+  end
+end


### PR DESCRIPTION
This plugin loads the forme plugin and prepends methods that extract
translations and merges them into the original method options

Input Labels: `models.<table_name>.<input>`
Association Subform Legends: `models.<table_name>.<association>`

It lacks adding the relevant information about this plugin on the README, if you don't have any particular preference in regard to this I can add myself.