### PR TITLE
Document extending transformers through new instance and call

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -84,6 +84,14 @@ passing the appropriate option to +input+ or +inputs+:
 
   f.input(:name, :wrapper=>:p)
 
+Existing transformers can be easily extended (ie, to set the class attribute),
+by creating your own transformer and then calling the existing transformer.
+
+  Forme.register_transformer(:labeler, :explicit) do |tag, input|
+    input.opts[:label_attr] ||= { :class => 'label' }
+    Forme::Labeler::Explicit.new.call(tag, input)
+  end
+
 = Installation
 
   gem install forme


### PR DESCRIPTION
Make it obvious that an entirely new transformer isn't required just to add new attributes to the existing one on a per-config basis.

I suspect the most common scenario for this is to add CSS classes.