### PR TITLE
Don't set default value for file inputs in Sequel plugin

### DIFF
--- a/lib/sequel/plugins/forme.rb
+++ b/lib/sequel/plugins/forme.rb
@@ -385,6 +385,7 @@ module Sequel # :nodoc:
           opts[:value] = nil
           standard_input(:file)
         end
+        alias input_file input_blob
 
         # Use the text type by default for other cases not handled.
         def input_string(sch)
@@ -420,12 +421,6 @@ module Sequel # :nodoc:
         # Use datetime inputs for datetimes.
         def input_datetime(sch)
           standard_input(:datetime)
-        end
-
-        # Use file inputs without value.
-        def input_file(sch)
-          opts[:value] = nil unless opts.has_key?(:value)
-          standard_input(:file)
         end
 
         # Use a text input for all other types.

--- a/lib/sequel/plugins/forme.rb
+++ b/lib/sequel/plugins/forme.rb
@@ -422,6 +422,12 @@ module Sequel # :nodoc:
           standard_input(:datetime)
         end
 
+        # Use file inputs without value.
+        def input_file(sch)
+          opts[:value] = nil unless opts.has_key?(:value)
+          standard_input(:file)
+        end
+
         # Use a text input for all other types.
         def input_other(sch)
           standard_input(:text)

--- a/spec/sequel_plugin_spec.rb
+++ b/spec/sequel_plugin_spec.rb
@@ -61,6 +61,14 @@ describe "Forme Sequel::Model forms" do
     @b.input(:created_at).to_s.must_equal '<label>Created at: <input id="album_created_at" name="album[created_at]" type="datetime-local" value="2011-06-05T00:00:00.000"/></label>'
   end
 
+  it "should use file inputs without value by default" do
+    @b.input(:name, :type=>:file).to_s.must_equal '<label>Name: <input id="album_name" name="album[name]" type="file"/></label>'
+  end
+
+  it "should support overriding file input value" do
+    @b.input(:name, :type=>:file, :value=>"foo").to_s.must_equal '<label>Name: <input id="album_name" name="album[name]" type="file" value="foo"/></label>'
+  end
+
   it "should include type as wrapper class" do
     @ab.values[:created_at] = DateTime.new(2011, 6, 5)
     f = Forme::Form.new(@ab, :wrapper=>:li)

--- a/spec/sequel_plugin_spec.rb
+++ b/spec/sequel_plugin_spec.rb
@@ -61,12 +61,8 @@ describe "Forme Sequel::Model forms" do
     @b.input(:created_at).to_s.must_equal '<label>Created at: <input id="album_created_at" name="album[created_at]" type="datetime-local" value="2011-06-05T00:00:00.000"/></label>'
   end
 
-  it "should use file inputs without value by default" do
+  it "should use file inputs without value" do
     @b.input(:name, :type=>:file).to_s.must_equal '<label>Name: <input id="album_name" name="album[name]" type="file"/></label>'
-  end
-
-  it "should support overriding file input value" do
-    @b.input(:name, :type=>:file, :value=>"foo").to_s.must_equal '<label>Name: <input id="album_name" name="album[name]" type="file" value="foo"/></label>'
   end
 
   it "should include type as wrapper class" do


### PR DESCRIPTION
File input fields aren't intended to have "value" set to them, they should be used only for selecting files. This improves integration with file attachment libraries like Shrine, where the "value" would otherwise be incorrectly set to a custom object that the attachment attribute
returns.