### PR TITLE
Allow overriding input type when using an associated object

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -244,11 +244,16 @@ object responds to +forme_input+, calls forme_input with the argument and option
 
 If the form has an associated object, and that object does not respond to +forme_input+,
 calls the method on the object (or uses [] if the object is a hash), and uses the result
-as the value:
+as the value for a text input:
 
   f = Forme::Form.new([:foo])
   f.input(:first) # '<input id="first" name="first" type="text" value="foo"/>'
-  
+
+You can change the type of the input via the +:type+ option:
+
+  f = Forme::Form.new(obj)
+  f.input(:field, :type=>:email) # '<input id="obj_field" name="obj[field]" type="email" value="foo"/>'
+
 If the form does not have an associated object, uses the first argument as the input
 type:
 
@@ -748,6 +753,7 @@ These options are supported by all of the input types:
 :name :: The name attribute to use
 :placeholder :: The placeholder attribute to use
 :required :: Set the required attribute if true
+:type :: Override the type of the input when the form has an associated object
 :value :: The value attribute to use for input tags, the content of the textarea
           for textarea tags, or the selected option(s) for select tags.
 :wrapper :: Set a custom wrapper, overriding the form's default

--- a/lib/forme/form.rb
+++ b/lib/forme/form.rb
@@ -138,14 +138,15 @@ module Forme
         else
           opts = opts.dup
           opts[:key] = field unless opts.has_key?(:key)
-          unless opts.has_key?(:value)
+          type = opts.delete(:type) || :text
+          unless opts.has_key?(:value) || type == :file
             opts[:value] = if obj.is_a?(Hash)
               obj[field]
             else
               obj.send(field)
             end
           end
-          _input(:text, opts)
+          _input(type, opts)
         end
       else
         _input(field, opts)

--- a/spec/forme_spec.rb
+++ b/spec/forme_spec.rb
@@ -1082,6 +1082,18 @@ describe "Forme object forms" do
   it "should be able to turn off obj handling per input using :obj=>nil option" do
     Forme::Form.new([:foo]).input(:checkbox, :name=>"foo", :hidden_value=>"no", :obj=>nil).to_s.must_equal '<input name="foo" type="hidden" value="no"/><input name="foo" type="checkbox"/>'
   end
+
+  it "should be able to change input type" do
+    Forme::Form.new([:foo]).input(:first, :type=>:email).to_s.must_equal  '<input id="first" name="first" type="email" value="foo"/>'
+  end
+
+  it "should not have default value for file input" do
+    Forme::Form.new([:foo]).input(:first, :type=>:file).to_s.must_equal  '<input id="first" name="first" type="file"/>'
+  end
+
+  it "should be able to set value for file input" do
+    Forme::Form.new([:foo]).input(:first, :type=>:file, :value=>"foo").to_s.must_equal  '<input id="first" name="first" type="file" value="foo"/>'
+  end
 end
 
 describe "Forme.form DSL" do


### PR DESCRIPTION
Overriding the input type when an associated object is used is currently only possible when using Sequel model instances (and the Sequel plugin loaded). When using a custom object, the input type is always "text".

This commit adds the :type option for overriding the input type (just like the :type option that the Sequel plugin supports). The field value from the object will be set for all input types except "file", as for file fields it semantically doesn't have any meaning and generally it's not desirable.