### PR TITLE
Omit labels for hidden inputs in Sequel plugin

### DIFF
--- a/lib/sequel/plugins/forme.rb
+++ b/lib/sequel/plugins/forme.rb
@@ -386,6 +386,12 @@ module Sequel # :nodoc:
           standard_input(:file)
         end
 
+        # Use hidden inputs without labels.
+        def input_hidden(sch)
+          opts[:label] = nil
+          standard_input(:hidden)
+        end
+
         # Use the text type by default for other cases not handled.
         def input_string(sch)
           if opts[:as] == :textarea

--- a/spec/sequel_plugin_spec.rb
+++ b/spec/sequel_plugin_spec.rb
@@ -43,6 +43,10 @@ describe "Forme Sequel::Model forms" do
     @b.input(:name, :type=>:textarea).to_s.must_equal '<label>Name: <textarea id="album_name" name="album[name]">b</textarea></label>'
     @c.input(:name, :type=>:textarea).to_s.must_equal '<label>Name: <textarea id="album_name" name="album[name]">c</textarea></label>'
   end
+
+  it "should not include labels for hidden inputs" do
+    @b.input(:name, :type=>:hidden).to_s.must_equal '<input id="album_name" name="album[name]" type="hidden" value="b"/>'
+  end
   
   it "should use number inputs for integers" do
     @b.input(:copies_sold).to_s.must_equal '<label>Copies sold: <input id="album_copies_sold" name="album[copies_sold]" type="number" value="10"/></label>'


### PR DESCRIPTION
I cannot imagine a scenario where one would want a label for a hidden
input, so I thought we could remove it. This means we don't have to explicitly
set `label: nil` anymore for hidden inputs.

Closes #23