### PR TITLE
Document the :obj input option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -751,6 +751,7 @@ These options are supported by all of the input types:
 :label :: Set a label, invoking the labeler
 :labeler :: Set a custom labeler, overriding the form's default
 :name :: The name attribute to use
+:obj :: Set the form object, overriding the form's default
 :placeholder :: The placeholder attribute to use
 :required :: Set the required attribute if true
 :type :: Override the type of the input when the form has an associated object


### PR DESCRIPTION
I was looking for a way to remove the form object for a certain field, and through reading the source code I found out that `:obj` can be overridden for a specific input. This PR adds the missing `:obj` option to the list of general input options.