### PR TITLE
Replace underscores with hyphens in symbol :data keys

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -739,6 +739,9 @@ These options are supported by all of the input types:
 :autofocus :: Set the autofocus attribute if true
 :class :: A class to use.  Unlike other options, this is combined with the
           classes set in the :attr hash.
+:dasherize_data :: Automatically replace underscores with hyphens for symbol
+                   data attribute names in the `:data` hash. Defaults to
+                   +false+.
 :data :: A hash of data-* attributes for the resulting tag.  Keys in this hash
          will have attributes created with data- prepended to the attribute name.
 :disabled :: Set the disabled attribute if true

--- a/lib/forme/transformers/formatter.rb
+++ b/lib/forme/transformers/formatter.rb
@@ -322,7 +322,7 @@ module Forme
 
       if data = opts[:data]
         data.each do |k, v|
-          k = k.to_s.tr("_", "-") if k.is_a?(Symbol)
+          k = k.to_s.tr("_", "-") if k.is_a?(Symbol) && input.opts[:dasherize_data]
           sym = :"data-#{k}"
           @attr[sym] = v unless @attr.has_key?(sym)
         end

--- a/lib/forme/transformers/formatter.rb
+++ b/lib/forme/transformers/formatter.rb
@@ -322,6 +322,7 @@ module Forme
 
       if data = opts[:data]
         data.each do |k, v|
+          k = k.to_s.tr("_", "-") if k.is_a?(Symbol)
           sym = :"data-#{k}"
           @attr[sym] = v unless @attr.has_key?(sym)
         end

--- a/spec/forme_spec.rb
+++ b/spec/forme_spec.rb
@@ -195,12 +195,12 @@ describe "Forme plain forms" do
     @f.input(:text, :data=>{:bar=>"foo"}).to_s.must_equal '<input data-bar="foo" type="text"/>'
   end
 
-  it "should replace underscores with hyphens in symbol :data keys" do
-    @f.input(:text, :data=>{:foo_bar=>"baz"}).to_s.must_equal '<input data-foo-bar="baz" type="text"/>'
-  end
-
-  it "should take string :data keys literally" do
+  it "should replace underscores with hyphens in symbol :data keys when :dasherize_data is set" do
+    @f.input(:text, :data=>{:foo_bar=>"baz"}).to_s.must_equal '<input data-foo_bar="baz" type="text"/>'
     @f.input(:text, :data=>{"foo_bar"=>"baz"}).to_s.must_equal '<input data-foo_bar="baz" type="text"/>'
+
+    @f.input(:text, :data=>{:foo_bar=>"baz"}, dasherize_data: true).to_s.must_equal '<input data-foo-bar="baz" type="text"/>'
+    @f.input(:text, :data=>{"foo_bar"=>"baz"}, dasherize_data: true).to_s.must_equal '<input data-foo_bar="baz" type="text"/>'
   end
 
   it "should not have standard options override the :attr option" do

--- a/spec/forme_spec.rb
+++ b/spec/forme_spec.rb
@@ -195,6 +195,14 @@ describe "Forme plain forms" do
     @f.input(:text, :data=>{:bar=>"foo"}).to_s.must_equal '<input data-bar="foo" type="text"/>'
   end
 
+  it "should replace underscores with hyphens in symbol :data keys" do
+    @f.input(:text, :data=>{:foo_bar=>"baz"}).to_s.must_equal '<input data-foo-bar="baz" type="text"/>'
+  end
+
+  it "should take string :data keys literally" do
+    @f.input(:text, :data=>{"foo_bar"=>"baz"}).to_s.must_equal '<input data-foo_bar="baz" type="text"/>'
+  end
+
   it "should not have standard options override the :attr option" do
     @f.input(:text, :name=>:bar, :attr=>{:name=>"foo"}).to_s.must_equal '<input name="foo" type="text"/>'
   end


### PR DESCRIPTION
This improves convenience of declaring "data" attributes with multiple words. Now users can use symbol keys with underscores:

```rb
f.input(:text, data: { foo_bar: "baz" })
```

and it will be automatically translated into:

```html
<input type="text" data-foo-bar="baz"/>
```

If the user wants to use underscores, they can use string keys instead, so

```rb
f.input(:text, data: { "foo_bar" => "baz" })
```

would translate into:

```html
<input type="text" data-foo_bar="baz">
```

This matches the behaviour of the Rails' form builder, and I think it makes sense because it's a convention with HTML attributes in general to use hyphen as a separator, and also JavaScript's `Node#dataset` camelizes the data attribute names using hyphen as a separator.