### PR TITLE
Add :errors option to Form

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -890,6 +890,8 @@ the defaults for Inputs created via the form:
 
 :config :: The configuration to use, which automatically sets defaults
            for the transformers to use.
+:errors :: A Hash of errors from a previous form submission, used to set
+           default errors for inputs when the inputs use the :key option.
 :error_handler :: Sets the default error_handler for the form's inputs
 :helper :: Sets the default helper for the form's inputs
 :formatter :: Sets the default formatter for the form's inputs

--- a/lib/forme/transformers/formatter.rb
+++ b/lib/forme/transformers/formatter.rb
@@ -316,6 +316,7 @@ module Forme
       copy_options_to_attributes(ATTRIBUTE_OPTIONS)
       copy_boolean_options_to_attributes(ATTRIBUTE_BOOLEAN_OPTIONS)
       handle_key_option
+      handle_errors_option
 
       Forme.attr_classes(@attr, @opts[:class]) if @opts.has_key?(:class)
       Forme.attr_classes(@attr, 'error') if @opts[:error]
@@ -344,6 +345,14 @@ module Forme
             id += "_#{suffix}"
           end
           @attr[:id] = id
+        end
+      end
+    end
+
+    def handle_errors_option
+      if key = @opts[:key]
+        if !@attr.has_key?(:error) && !@attr.has_key?("error") && (errors = @form.opts[:errors])
+          set_error_from_namespaced_errors(namespaces, errors, key)
         end
       end
     end
@@ -384,6 +393,16 @@ module Forme
       end
 
       @attr[:value] = values.fetch(key){values.fetch(key.to_s){return}}
+    end
+
+    def set_error_from_namespaced_errors(namespaces, errors, key)
+      namespaces.each do |ns|
+        e = errors[ns] || errors[ns.to_s]
+        return unless e
+        errors = e
+      end
+
+      @opts[:error] = errors.fetch(key){errors.fetch(key.to_s){return}}
     end
 
     # If :optgroups option is present, iterate over each of the groups

--- a/spec/forme_spec.rb
+++ b/spec/forme_spec.rb
@@ -114,6 +114,18 @@ describe "Forme plain forms" do
     end
   end
 
+  it "should consider form's :errors hash based on the :key option" do
+    @f.opts[:errors] = { 'foo' => 'must be present' }
+    @f.input(:text, :key=>"foo").to_s.must_equal "<input class=\"error\" id=\"foo\" name=\"foo\" type=\"text\"/><span class=\"error_message\">must be present</span>"
+  end
+
+  it "should consider form's :errors hash based on the :key option when using namespaces" do
+    @f.opts[:errors] = { 'bar' => { 'foo' => 'must be present' } }
+    @f.with_opts(:namespace=>['bar']) do
+      @f.input(:text, :key=>"foo").to_s.must_equal "<input class=\"error\" id=\"bar_foo\" name=\"bar[foo]\" type=\"text\"/><span class=\"error_message\">must be present</span>"
+    end
+  end
+
   it "should support a with_obj method that changes the object and namespace for the given block" do
     @f.with_obj([:a, :c], 'bar') do
       @f.input(:first).to_s.must_equal '<input id="bar_first" name="bar[first]" type="text" value="a"/>'


### PR DESCRIPTION
This :errors option is akin to the :values option, for when an input
has a :key option, the :errors option on the Form object is checked for a
corresponding error message, which is then applied to the Input if one
is not already present.