### PR TITLE
Update bs3 formatter

### DIFF
--- a/lib/forme/bs3.rb
+++ b/lib/forme/bs3.rb
@@ -80,12 +80,26 @@ module Forme
       copy_options_to_attributes(ATTRIBUTE_OPTIONS)
       copy_boolean_options_to_attributes(ATTRIBUTE_BOOLEAN_OPTIONS)
       handle_key_option
+      handle_errors_option
 
       Forme.attr_classes(@attr, @opts[:class]) if @opts.has_key?(:class)
-      # Forme.attr_classes(@attr, 'error') if @opts[:error]
+
+      if @opts[:error]
+        # Forme.attr_classes(@attr, 'error')
+        @attr["aria-invalid"] = "true"
+        if @opts.fetch(:error_handler, true)
+          unless @opts[:error_id]
+            if id = @attr[:id] || @attr['id']
+              error_id = @attr['aria-describedby'] ||= "#{id}_error_message"
+              @opts[:error_id] = error_id
+            end
+          end
+        end
+      end
 
       if data = opts[:data]
         data.each do |k, v|
+          k = k.to_s.tr("_", "-") if k.is_a?(Symbol) && input.opts[:dasherize_data]
           sym = :"data-#{k}"
           @attr[sym] = v unless @attr.has_key?(sym)
         end

--- a/spec/bs3_reference_spec.rb
+++ b/spec/bs3_reference_spec.rb
@@ -33,7 +33,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
     end
     
     it "should create an input[:text] tag with a label when ':id => bar' with an error" do
-      @f.input(:text, :label=>"Name", :id=>'bar', :class=>'foo', :error=>'input-text-error').to_s.must_equal '<div class="form-group has-error"><label for="bar">Name</label> <input class="form-control foo" id="bar" type="text"/><span class="help-block with-errors">input-text-error</span></div>'
+      @f.input(:text, :label=>"Name", :id=>'bar', :class=>'foo', :error=>'input-text-error').to_s.must_equal '<div class="form-group has-error"><label for="bar">Name</label> <input aria-describedby="bar_error_message" aria-invalid="true" class="form-control foo" id="bar" type="text"/><span class="help-block with-errors">input-text-error</span></div>'
     end
     
     describe 'from a Sequel model' do
@@ -43,7 +43,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
       
       it "should correctly handle an input[:text] tag from Sequel model with error" do
         @ac.errors.add(:name, 'name not valid')
-        @c.input(:name).to_s.must_equal '<div class="form-group has-error string"><label for="album_name">Name</label> <input class="form-control" id="album_name" maxlength="255" name="album[name]" type="text" value="c"/><span class="help-block with-errors">name not valid</span></div>'
+        @c.input(:name).to_s.must_equal '<div class="form-group has-error string"><label for="album_name">Name</label> <input aria-describedby="album_name_error_message" aria-invalid="true" class="form-control" id="album_name" maxlength="255" name="album[name]" type="text" value="c"/><span class="help-block with-errors">name not valid</span></div>'
       end
     end
   end
@@ -66,7 +66,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
     end
     
     it "should create an input[:password] tag with a label when ':id => bar' with an error" do
-      @f.input(:password, :label=>"Name", :id=>'bar', :class=>'foo', :error=>'input-password-error').to_s.must_equal '<div class="form-group has-error"><label for="bar">Name</label> <input class="form-control foo" id="bar" type="password"/><span class="help-block with-errors">input-password-error</span></div>'
+      @f.input(:password, :label=>"Name", :id=>'bar', :class=>'foo', :error=>'input-password-error').to_s.must_equal '<div class="form-group has-error"><label for="bar">Name</label> <input aria-describedby="bar_error_message" aria-invalid="true" class="form-control foo" id="bar" type="password"/><span class="help-block with-errors">input-password-error</span></div>'
     end
   end
   
@@ -88,7 +88,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
     end
     
     it "should create an input[:email] tag with a label when ':id => bar' with an error" do
-      @f.input(:email, :label=>"Name", :id=>'bar', :class=>'foo', :error=>'input-email-error').to_s.must_equal '<div class="form-group has-error"><label for="bar">Name</label> <input class="form-control foo" id="bar" type="email"/><span class="help-block with-errors">input-email-error</span></div>'
+      @f.input(:email, :label=>"Name", :id=>'bar', :class=>'foo', :error=>'input-email-error').to_s.must_equal '<div class="form-group has-error"><label for="bar">Name</label> <input aria-describedby="bar_error_message" aria-invalid="true" class="form-control foo" id="bar" type="email"/><span class="help-block with-errors">input-email-error</span></div>'
     end
   end
   
@@ -110,7 +110,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
     end
     
     it "should create an input[:file] tag with a label when ':id => bar' with an error" do
-      @f.input(:file, :label=>"Name", :id=>'bar', :class=>'foo', :error=>'input-file-error').to_s.must_equal '<div class="form-group has-error"><label for="bar">Name</label> <input class="foo" id="bar" type="file"/><span class="help-block with-errors">input-file-error</span></div>'
+      @f.input(:file, :label=>"Name", :id=>'bar', :class=>'foo', :error=>'input-file-error').to_s.must_equal '<div class="form-group has-error"><label for="bar">Name</label> <input aria-describedby="bar_error_message" aria-invalid="true" class="foo" id="bar" type="file"/><span class="help-block with-errors">input-file-error</span></div>'
     end
   end
   
@@ -132,7 +132,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
     end
     
     it "should create an input[:submit] tag without error message " do
-      @f.input(:submit, :value=>'Save', :id=>'foo', :error=>'error-message').to_s.must_equal '<input class="btn btn-default" id="foo" type="submit" value="Save"/>'
+      @f.input(:submit, :value=>'Save', :id=>'foo', :error=>'error-message').to_s.must_equal '<input aria-describedby="foo_error_message" aria-invalid="true" class="btn btn-default" id="foo" type="submit" value="Save"/>'
     end
   end
   
@@ -154,7 +154,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
     end
   
     it "should create an input[:reset] tag without error message " do
-      @f.input(:reset, :value=>'Save', :id=>'foo', :error=>'error-message').to_s.must_equal '<input class="btn btn-default" id="foo" type="reset" value="Save"/>'
+      @f.input(:reset, :value=>'Save', :id=>'foo', :error=>'error-message').to_s.must_equal '<input aria-describedby="foo_error_message" aria-invalid="true" class="btn btn-default" id="foo" type="reset" value="Save"/>'
     end
   end
   
@@ -180,7 +180,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
     end
   
     it "should create a textarea tag with .has-error and error message when ':error => is-a-string'" do
-      @f.input(:textarea, :error=>'input-textarea-error').to_s.must_equal '<div class="form-group has-error"><textarea class="form-control"></textarea><span class="help-block with-errors">input-textarea-error</span></div>'
+      @f.input(:textarea, :error=>'input-textarea-error').to_s.must_equal '<div class="form-group has-error"><textarea aria-invalid="true" class="form-control"></textarea><span class="help-block with-errors">input-textarea-error</span></div>'
     end
     
     describe 'from a Sequel model' do
@@ -190,7 +190,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
       
       it "should correctly handle an input[:text] tag from Sequel model with error" do
         @ac.errors.add(:name, 'name not valid')
-        @c.input(:name, :as=>:textarea).to_s.must_equal '<div class="form-group has-error string"><label for="album_name">Name</label> <textarea class="form-control" id="album_name" maxlength="255" name="album[name]">c</textarea><span class="help-block with-errors">name not valid</span></div>'
+        @c.input(:name, :as=>:textarea).to_s.must_equal '<div class="form-group has-error string"><label for="album_name">Name</label> <textarea aria-describedby="album_name_error_message" aria-invalid="true" class="form-control" id="album_name" maxlength="255" name="album[name]">c</textarea><span class="help-block with-errors">name not valid</span></div>'
       end
     end
   end
@@ -225,7 +225,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
     end
     
     it "should create a select tag with .has-error and error message when ':error => is-a-string'" do
-      @f.input(:select, :error=>'input-select-error').to_s.must_equal '<div class="form-group has-error"><select class="form-control"></select><span class="help-block with-errors">input-select-error</span></div>'
+      @f.input(:select, :error=>'input-select-error').to_s.must_equal '<div class="form-group has-error"><select aria-invalid="true" class="form-control"></select><span class="help-block with-errors">input-select-error</span></div>'
     end
     
     it "should correctly handle a Sequel model output :as => :select" do
@@ -234,7 +234,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
     
     it "should correctly handle a Sequel model output :as => :select with error" do
       @ac.errors.add(:artist, 'error message')
-      @c.input(:artist, :as=>:select).to_s.must_equal '<div class="form-group has-error many_to_one"><label for="album_artist_id">Artist</label> <select class="form-control" id="album_artist_id" name="album[artist_id]"><option value=""></option><option value="1">a</option><option selected="selected" value="2">d</option></select><span class="help-block with-errors">error message</span></div>'
+      @c.input(:artist, :as=>:select).to_s.must_equal '<div class="form-group has-error many_to_one"><label for="album_artist_id">Artist</label> <select aria-describedby="album_artist_id_error_message" aria-invalid="true" class="form-control" id="album_artist_id" name="album[artist_id]"><option value=""></option><option value="1">a</option><option selected="selected" value="2">d</option></select><span class="help-block with-errors">error message</span></div>'
     end
     
     describe 'from a Sequel model' do
@@ -244,7 +244,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
       
       it "should correctly handle a boolean attribute from a Sequel model with an error" do
         @ac.errors.add(:gold, 'error message')
-        @c.input(:gold).to_s.must_equal '<div class="boolean form-group has-error"><label for="album_gold">Gold</label> <select class="form-control" id="album_gold" name="album[gold]"><option value=""></option><option selected="selected" value="t">True</option><option value="f">False</option></select><span class="help-block with-errors">error message</span></div>'
+        @c.input(:gold).to_s.must_equal '<div class="boolean form-group has-error"><label for="album_gold">Gold</label> <select aria-describedby="album_gold_error_message" aria-invalid="true" class="form-control" id="album_gold" name="album[gold]"><option value=""></option><option selected="selected" value="t">True</option><option value="f">False</option></select><span class="help-block with-errors">error message</span></div>'
       end
     end
   end
@@ -267,7 +267,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
     end
     
     it "should create an input[:checkbox] tag with a label when ':id => bar' with an error" do
-      @f.input(:checkbox, :label=>"Gold", :id=>'bar', :class=>'foo', :error=>'input-checkbox-error').to_s.must_equal '<div class="has-error"><div class="checkbox"><label for="bar"><input class="foo" id="bar" type="checkbox"/> Gold</label></div><span class="help-block with-errors">input-checkbox-error</span></div>'
+      @f.input(:checkbox, :label=>"Gold", :id=>'bar', :class=>'foo', :error=>'input-checkbox-error').to_s.must_equal '<div class="has-error"><div class="checkbox"><label for="bar"><input aria-describedby="bar_error_message" aria-invalid="true" class="foo" id="bar" type="checkbox"/> Gold</label></div><span class="help-block with-errors">input-checkbox-error</span></div>'
     end
     
     describe 'from a Sequel model' do
@@ -277,7 +277,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
     
       it "should correctly handle a boolean attribute ':as=>:checkbox' with an error" do
         @ac.errors.add(:gold, 'error message')
-        @c.input(:gold, :as=>:checkbox).to_s.must_equal '<div class="boolean has-error"><div class="checkbox"><label for="album_gold"><input id="album_gold_hidden" name="album[gold]" type="hidden" value="f"/><input checked="checked" id="album_gold" name="album[gold]" type="checkbox" value="t"/> Gold</label></div><span class="help-block with-errors">error message</span></div>'
+        @c.input(:gold, :as=>:checkbox).to_s.must_equal '<div class="boolean has-error"><div class="checkbox"><label for="album_gold"><input id="album_gold_hidden" name="album[gold]" type="hidden" value="f"/><input aria-describedby="album_gold_error_message" aria-invalid="true" checked="checked" id="album_gold" name="album[gold]" type="checkbox" value="t"/> Gold</label></div><span class="help-block with-errors">error message</span></div>'
       end
     end
   end
@@ -301,7 +301,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
     end
     
     it "should create an input[:radio] tag with a label when ':id => bar' with an error" do
-      @f.input(:radio, :label=>"Gold", :id=>'bar', :class=>'foo', :error=>'input-radio-error').to_s.must_equal '<div class="has-error"><div class="radio"><label for="bar"><input class="foo" id="bar" type="radio"/> Gold</label></div><span class="help-block with-errors">input-radio-error</span></div>'
+      @f.input(:radio, :label=>"Gold", :id=>'bar', :class=>'foo', :error=>'input-radio-error').to_s.must_equal '<div class="has-error"><div class="radio"><label for="bar"><input aria-describedby="bar_error_message" aria-invalid="true" class="foo" id="bar" type="radio"/> Gold</label></div><span class="help-block with-errors">input-radio-error</span></div>'
     end
     
     describe 'from a Sequel model' do

--- a/spec/bs3_sequel_plugin_spec.rb
+++ b/spec/bs3_sequel_plugin_spec.rb
@@ -263,7 +263,7 @@ describe "Forme Sequel::Model BS3 forms" do
 
   it "should handle an error message on the underlying column for pg_array_to_many associations" do
     @ab.errors.add(:atag_ids, 'tis not valid')
-    @b.input(:atags).to_s.must_equal '<div class="form-group has-error pg_array_to_many"><label for="album_atag_ids">Atags</label> <select class="form-control" id="album_atag_ids" multiple="multiple" name="album[atag_ids][]"><option selected="selected" value="1">s</option><option selected="selected" value="2">t</option><option value="3">u</option></select><span class="help-block with-errors">tis not valid</span></div>'
+    @b.input(:atags).to_s.must_equal '<div class="form-group has-error pg_array_to_many"><label for="album_atag_ids">Atags</label> <select aria-describedby="album_atag_ids_error_message" aria-invalid="true" class="form-control" id="album_atag_ids" multiple="multiple" name="album[atag_ids][]"><option selected="selected" value="1">s</option><option selected="selected" value="2">t</option><option value="3">u</option></select><span class="help-block with-errors">tis not valid</span></div>'
     @b.input(:atags, :as=>:checkbox).to_s.must_equal '<div class="pg_array_to_many checkboxset has-error"><label>Atags</label><div class="checkbox"><label class="option" for="album_atag_ids_1"><input checked="checked" id="album_atag_ids_1" name="album[atag_ids][]" type="checkbox" value="1"/> s</label></div><div class="checkbox"><label class="option" for="album_atag_ids_2"><input checked="checked" id="album_atag_ids_2" name="album[atag_ids][]" type="checkbox" value="2"/> t</label></div><div class="checkbox"><label class="option" for="album_atag_ids_3"><input id="album_atag_ids_3" name="album[atag_ids][]" type="checkbox" value="3"/> u</label></div><span class="help-block with-errors">tis not valid</span></div>'
     @b.input(:atags, :as=>:checkbox,:wrapper=>:li).to_s.must_equal '<li class="pg_array_to_many checkboxset has-error"><label>Atags</label><div class="checkbox"><label class="option" for="album_atag_ids_1"><input checked="checked" id="album_atag_ids_1" name="album[atag_ids][]" type="checkbox" value="1"/> s</label></div><div class="checkbox"><label class="option" for="album_atag_ids_2"><input checked="checked" id="album_atag_ids_2" name="album[atag_ids][]" type="checkbox" value="2"/> t</label></div><div class="checkbox"><label class="option" for="album_atag_ids_3"><input id="album_atag_ids_3" name="album[atag_ids][]" type="checkbox" value="3"/> u</label></div><span class="help-block with-errors">tis not valid</span></li>'
   end
@@ -308,7 +308,7 @@ describe "Forme Sequel::Model BS3 forms" do
 
   it "should handle errors on methods not backed by columns" do
     @ab.errors.add(:artist_name, 'foo')
-    @b.input(:artist_name).to_s.must_equal '<div class="form-group has-error"><label for="album_artist_name">Artist name</label> <input class="form-control" id="album_artist_name" name="album[artist_name]" type="text" value="a"/><span class="help-block with-errors">foo</span></div>'
+    @b.input(:artist_name).to_s.must_equal '<div class="form-group has-error"><label for="album_artist_name">Artist name</label> <input aria-describedby="album_artist_name_error_message" aria-invalid="true" class="form-control" id="album_artist_name" name="album[artist_name]" type="text" value="a"/><span class="help-block with-errors">foo</span></div>'
   end
 
   it "should respect a :type option with a schema type as the input type for methods not backed by columns" do
@@ -323,12 +323,12 @@ describe "Forme Sequel::Model BS3 forms" do
 
   it "should correctly show an error message if there is one" do
     @ab.errors.add(:name, 'tis not valid')
-    @b.input(:name).to_s.must_equal '<div class="form-group has-error string"><label for="album_name">Name</label> <input class="form-control" id="album_name" maxlength="255" name="album[name]" type="text" value="b"/><span class="help-block with-errors">tis not valid</span></div>'
+    @b.input(:name).to_s.must_equal '<div class="form-group has-error string"><label for="album_name">Name</label> <input aria-describedby="album_name_error_message" aria-invalid="true" class="form-control" id="album_name" maxlength="255" name="album[name]" type="text" value="b"/><span class="help-block with-errors">tis not valid</span></div>'
   end
 
   it "should correctly show an error message for many_to_one associations if there is one" do
     @ab.errors.add(:artist_id, 'tis not valid')
-    @b.input(:artist).to_s.must_equal '<div class="form-group has-error many_to_one"><label for="album_artist_id">Artist</label> <select class="form-control" id="album_artist_id" name="album[artist_id]"><option value=""></option><option selected="selected" value="1">a</option><option value="2">d</option></select><span class="help-block with-errors">tis not valid</span></div>'
+    @b.input(:artist).to_s.must_equal '<div class="form-group has-error many_to_one"><label for="album_artist_id">Artist</label> <select aria-describedby="album_artist_id_error_message" aria-invalid="true" class="form-control" id="album_artist_id" name="album[artist_id]"><option value=""></option><option selected="selected" value="1">a</option><option value="2">d</option></select><span class="help-block with-errors">tis not valid</span></div>'
   end
 
   it "should raise an error for unhandled associations" do

--- a/spec/bs3_spec.rb
+++ b/spec/bs3_spec.rb
@@ -99,6 +99,18 @@ describe "Forme Bootstrap3 (BS3) forms" do
     end
   end
 
+  it "should consider form's :errors hash based on the :key option" do
+    @f.opts[:errors] = { 'foo' => 'must be present' }
+    @f.input(:text, :key=>"foo").to_s.must_equal "<div class=\"form-group has-error\"><input aria-describedby=\"foo_error_message\" aria-invalid=\"true\" class=\"form-control\" id=\"foo\" name=\"foo\" type=\"text\"/><span class=\"help-block with-errors\">must be present</span></div>"
+  end
+
+  it "should consider form's :errors hash based on the :key option when using namespaces" do
+    @f.opts[:errors] = { 'bar' => { 'foo' => 'must be present' } }
+    @f.with_opts(:namespace=>['bar']) do
+      @f.input(:text, :key=>"foo").to_s.must_equal "<div class=\"form-group has-error\"><input aria-describedby=\"bar_foo_error_message\" aria-invalid=\"true\" class=\"form-control\" id=\"bar_foo\" name=\"bar[foo]\" type=\"text\"/><span class=\"help-block with-errors\">must be present</span></div>"
+    end
+  end
+
   it "should support a with_obj method that changes the object and namespace for the given block" do
     @f.with_obj([:a, :c], 'bar') do
       @f.input(:first).to_s.must_equal '<div class="form-group"><input class="form-control" id="bar_first" name="bar[first]" type="text" value="a"/></div>'
@@ -481,19 +493,19 @@ describe "Forme Bootstrap3 (BS3) forms" do
   end
 
   it "should automatically note the input has errors if :error option is used" do
-    @f.input(:text, :error=>'Bad Stuff!', :value=>'foo').to_s.must_equal '<div class="form-group has-error"><input class="form-control" type="text" value="foo"/><span class="help-block with-errors">Bad Stuff!</span></div>'
+    @f.input(:text, :error=>'Bad Stuff!', :value=>'foo').to_s.must_equal '<div class="form-group has-error"><input aria-invalid="true" class="form-control" type="text" value="foo"/><span class="help-block with-errors">Bad Stuff!</span></div>'
   end
 
   it "should add an error message after the label" do
-    @f.input(:text, :error=>'Bad Stuff!', :value=>'foo', :label=>"Foo").to_s.must_equal '<div class="form-group has-error"><label>Foo</label> <input class="form-control" type="text" value="foo"/><span class="help-block with-errors">Bad Stuff!</span></div>'
+    @f.input(:text, :error=>'Bad Stuff!', :value=>'foo', :label=>"Foo").to_s.must_equal '<div class="form-group has-error"><label>Foo</label> <input aria-invalid="true" class="form-control" type="text" value="foo"/><span class="help-block with-errors">Bad Stuff!</span></div>'
   end
 
   it "should add to existing :class option if :error option is used" do
-    @f.input(:text, :error=>'Bad Stuff!', :class=>'bar', :value=>'foo').to_s.must_equal '<div class="form-group has-error"><input class="form-control bar" type="text" value="foo"/><span class="help-block with-errors">Bad Stuff!</span></div>'
+    @f.input(:text, :error=>'Bad Stuff!', :class=>'bar', :value=>'foo').to_s.must_equal '<div class="form-group has-error"><input aria-invalid="true" class="form-control bar" type="text" value="foo"/><span class="help-block with-errors">Bad Stuff!</span></div>'
   end
 
   it "should respect :error_attr option for setting the attributes for the error message span" do
-    @f.input(:text, :error=>'Bad Stuff!', :value=>'foo', :error_attr=>{:class=>'foo'}).to_s.must_equal '<div class="form-group has-error"><input class="form-control" type="text" value="foo"/><span class="foo help-block with-errors">Bad Stuff!</span></div>'
+    @f.input(:text, :error=>'Bad Stuff!', :value=>'foo', :error_attr=>{:class=>'foo'}).to_s.must_equal '<div class="form-group has-error"><input aria-invalid="true" class="form-control" type="text" value="foo"/><span class="foo help-block with-errors">Bad Stuff!</span></div>'
   end
 
   it "#open should return an opening tag" do
@@ -624,7 +636,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
   end
 
   it "inputs should have helper displayed inside wrapper, after error" do
-    @f.input(:text, :help=>"List type of foo", :error=>'bad', :wrapper=>:li).to_s.must_equal '<li class="has-error"><input class="form-control" type="text"/><span class="help-block with-errors">bad</span><span class="helper">List type of foo</span></li>'
+    @f.input(:text, :help=>"List type of foo", :error=>'bad', :wrapper=>:li).to_s.must_equal '<li class="has-error"><input aria-invalid="true" class="form-control" type="text"/><span class="help-block with-errors">bad</span><span class="helper">List type of foo</span></li>'
   end
 
   it "inputs should accept a :formatter option to use a custom formatter" do
@@ -661,7 +673,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
   end
 
   it "inputs should accept a :error_handler option to use a custom error_handler" do
-    @f.input(:textarea, :error_handler=>proc{|t, i| [t, "!!! #{i.opts[:error]}"]}, :error=>'bar', :id=>:foo).to_s.must_equal '<div class="form-group"><textarea class="form-control" id="foo"></textarea>!!! bar</div>'
+    @f.input(:textarea, :error_handler=>proc{|t, i| [t, "!!! #{i.opts[:error]}"]}, :error=>'bar', :id=>:foo).to_s.must_equal '<div class="form-group"><textarea aria-describedby="foo_error_message" aria-invalid="true" class="form-control" id="foo"></textarea>!!! bar</div>'
   end
 
   it "#inputs should accept a :inputs_wrapper option to use a custom inputs_wrapper" do
@@ -679,7 +691,7 @@ describe "Forme Bootstrap3 (BS3) forms" do
   end
 
   it "inputs should accept a :error_handler=>nil option to not use an error_handler" do
-    @f.input(:textarea, :error_handler=>nil, :error=>'bar', :id=>:foo).to_s.must_equal '<div class="form-group"><textarea class="form-control" id="foo"></textarea></div>'
+    @f.input(:textarea, :error_handler=>nil, :error=>'bar', :id=>:foo).to_s.must_equal '<div class="form-group"><textarea aria-invalid="true" class="form-control" id="foo"></textarea></div>'
   end
 
   it "#inputs should accept a :inputs_wrapper=>nil option to not use an inputs_wrapper" do


### PR DESCRIPTION
The generic formatter's `#normalize_options` method is copied over bs3's
formatter with the only purpose to remove the `error` class that is
added to the input. The copied version had become staled and it lacked two
new features:

- Errors defined at the form level through the `:errors` key (see
  https://github.com/jeremyevans/forme/pull/32).
- The addition of accessibility attributes `aria-invalid` and
  `aria-describedby` (see
  https://github.com/jeremyevans/forme/commit/d070e6a1508c7427bc29581925f6a462e835b971).

This commit updates the copied version, updates tests to contain `aria-`
attributes and add tests for the `errors:` option.