### PR TITLE
Allow loading forme_set Sequel plugin without requiring Forme

### DIFF
--- a/lib/sequel/plugins/forme_set.rb
+++ b/lib/sequel/plugins/forme_set.rb
@@ -1,5 +1,7 @@
 # frozen-string-literal: true
 
+require_relative '../../forme'
+
 module Sequel # :nodoc:
   module Plugins # :nodoc:
     # The forme_set plugin makes the model instance keep track of which form


### PR DESCRIPTION
When loading the `forme_set` Sequel plugin, I currently get a `NameError` if I don't require Forme, because the Forme class is referenced while loading the code. I see that the `forme` Sequel plugin requires Forme, so this makes the same change for `forme_set`.
