### PR TITLE
Remind about loading the forme_set Sequel plugin

### DIFF
--- a/lib/roda/plugins/forme_set.rb
+++ b/lib/roda/plugins/forme_set.rb
@@ -27,8 +27,8 @@ class Roda
 
       # Map of error types to error messages
       ERROR_MESSAGES = {
-        :missing_data=>"_forme_set_data parameter not submitted",
-        :missing_hmac=>"_forme_set_data_hmac parameter not submitted",
+        :missing_data=>"_forme_set_data parameter not submitted, make sure the forme_set Sequel plugin is loaded",
+        :missing_hmac=>"_forme_set_data_hmac parameter not submitted, make sure the forme_set Sequel plugin is loaded",
         :hmac_mismatch=>"_forme_set_data_hmac does not match _forme_set_data",
         :csrf_mismatch=>"_forme_set_data CSRF token does not match submitted CSRF token",
         :missing_namespace=>"no content in expected namespace"


### PR DESCRIPTION
These fields will usually be missing when the `forme_set` Sequel plugin is not loaded, so we let user know that it's the likely problem.

It happened to me twice that I had accidentally loaded the `forme` Sequel plugin instead of `forme_set`, and both times it took me a while before I pinpointed the problem to the missing Sequel plugin. So, I think this addition can save the user some time.
