### PR TITLE
Raise error when :secret option is not provided to forme_set roda plugin

### DIFF
--- a/lib/roda/plugins/forme_set.rb
+++ b/lib/roda/plugins/forme_set.rb
@@ -15,6 +15,8 @@ class Roda
       def self.configure(app, opts = OPTS, &block)
         app.opts[:forme_set_hmac_secret] = opts[:secret] || app.opts[:forme_set_hmac_secret]
 
+        raise RodaError, "must provide :secret option to forme_set plugin" unless app.opts[:forme_set_hmac_secret]
+
         if block
           app.send(:define_method, :_forme_set_handle_error, &block)
           app.send(:private, :_forme_set_handle_error)

--- a/spec/roda_integration_spec.rb
+++ b/spec/roda_integration_spec.rb
@@ -535,6 +535,12 @@ END
     it "should handle forms with objects that don't support forme_inputs" do
       forme_set(String, {:name=>'Foo'}, {}, :inputs=>[:name])['body'].must_equal '<form><fieldset class="inputs"><input id="name" name="name" type="text" value="String"/></fieldset></form>'
     end
+
+    it "should require :secret plugin option" do
+      app = FormeRodaTest()
+      error = proc{app.plugin(:forme_set)}.must_raise Roda::RodaError
+      error.message.must_equal "must provide :secret option to forme_set plugin"
+    end
   end
 end
 end


### PR DESCRIPTION
This plugin option is required later when generating the HMAC for the form, and if it's missing it raises a less obvious `TypeError`. So we make sure we require it when loading the plugin.
