### PR TITLE
Add configuration for Bootstrap 5

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1264,11 +1264,16 @@ You can mark a configuration as the default using:
 
   Forme.default_config = :mine
 
-=== Bootstrap 3 Support
+=== Bootstrap Support
 
-Forme ships with support for Bootstrap 3-4 HTML formatting. This support is shipped in
+Forme ships with support for Bootstrap 5 HTML formatting. This support is shipped in
 it's own file, so if you don't use it, you don't pay the memory penalty for loading
 it.
+
+  require 'forme/bs5'
+  Forme.default_config = :bs5
+
+There is also support for Bootstrap versions 3-4:
 
   require 'forme/bs3'
   Forme.default_config = :bs3

--- a/demo-site/forme_demo.rb
+++ b/demo-site/forme_demo.rb
@@ -1,7 +1,7 @@
 require 'tilt/erubi'
 require 'roda'
 require_relative 'models'
-require 'forme/bs3'
+require 'forme/bs5'
 
 class FormeDemo::App < Roda
   include FormeDemo
@@ -132,43 +132,43 @@ class FormeDemo::App < Roda
 
       end
 
-      r.on 'bs3' do
+      r.on 'bs5' do
         r.on 'album' do
           r.on 'basic' do
             r.is 'default' do
-              @page_title = 'BS3: Album Basic - Default'
-              @form_opts_base = { :config=>:bs3 }
+              @page_title = 'BS5: Album Basic - Default'
+              @form_opts_base = { :config=>:bs5 }
               demo :album_basic
             end
 
             r.is 'table' do
-              @page_title = 'BS3: Album Basic - Table'
-              @form_opts_base = { :config=>:bs3, :wrapper=>:trtd, :inputs_wrapper=>:bs3_table }
+              @page_title = 'BS5: Album Basic - Table'
+              @form_opts_base = { :config=>:bs5, :wrapper=>:trtd, :inputs_wrapper=>:bs5_table }
               demo :album_basic
             end
 
             r.is 'list' do
-              @page_title = 'BS3: Album Basic - List'
-              @form_opts_base = {:config=>:bs3, :wrapper=>:li, :inputs_wrapper=>:ol}
+              @page_title = 'BS5: Album Basic - List'
+              @form_opts_base = {:config=>:bs5, :wrapper=>:li, :inputs_wrapper=>:ol}
               @css = "ol, li {list-style-type: none;}"
               demo :album_basic
             end
 
             r.is 'date' do
-              @page_title = 'BS3: Album Basic - Date Multiple Select Boxes'
-              @form_opts_base = {:config=>:bs3, :date=>{:as=>:select}, :wrapper=>:trtd, :inputs_wrapper=>:bs3_table}
+              @page_title = 'BS5: Album Basic - Date Multiple Select Boxes'
+              @form_opts_base = {:config=>:bs5, :date=>{:as=>:select}, :wrapper=>:trtd, :inputs_wrapper=>:bs5_table}
               demo :album_basic
             end
 
             r.is 'alt_assoc' do
               @page_title = 'Album Basic - Association Radios/Checkboxes'
-              @form_opts_base = {:config=>:bs3, :many=>{:as=>:checkbox}, :one=>{:as=>:radio} }
+              @form_opts_base = {:config=>:bs5, :many=>{:as=>:checkbox}, :one=>{:as=>:radio} }
               demo :album_basic
             end
 
             r.is 'readonly' do
-              @page_title = 'BS3: Album Basic - Read Only'
-              @form_opts_base = {:config=>:bs3, :formatter=>:bs3_readonly}
+              @page_title = 'BS5: Album Basic - Read Only'
+              @form_opts_base = {:config=>:bs5, :formatter=>:bs5_readonly}
               @css = "ol, li {list-style-type: none;}"
               demo :album_basic
             end
@@ -176,9 +176,9 @@ class FormeDemo::App < Roda
           end
           
           r.is 'nested' do
-            @page_title = 'BS3: Single Level Nesting'
-            @form_opts_base = { :config=>:bs3 }
-            @subform_opts = { :config=>:bs3 }
+            @page_title = 'BS5: Single Level Nesting'
+            @form_opts_base = { :config=>:bs5 }
+            @subform_opts = { :config=>:bs5 }
             demo :album_nested
           end
           
@@ -186,9 +186,9 @@ class FormeDemo::App < Roda
         
         r.on 'artist' do
           r.is 'nested' do
-            @page_title = 'BS3: - Multiple Level Nesting'
-            @form_opts_base = { :config=>:bs3 }
-            @subform_opts = { :config=>:bs3 }
+            @page_title = 'BS5: - Multiple Level Nesting'
+            @form_opts_base = { :config=>:bs5 }
+            @subform_opts = { :config=>:bs5 }
             demo :artist_nested
           end
         end

--- a/demo-site/public/css/forme_demo.css
+++ b/demo-site/public/css/forme_demo.css
@@ -56,3 +56,7 @@ table caption {font-size: 20px; margin-bottom: 10px;}
 
 div.readonly-textarea { display: inline-block;}
 div.readonly-textarea p:last-child { margin-bottom: 0;}
+
+.inputs > div {
+  margin-bottom: 1rem;
+}

--- a/demo-site/views/index.erb
+++ b/demo-site/views/index.erb
@@ -1,4 +1,4 @@
-<h1>Overview</h1>
+<h2>Overview</h1>
 
 <p>This is the demo site for <a href="https://github.com/jeremyevans/forme">Forme</a>.  Forme is a HTML forms library for ruby with the following goals:</p>
 
@@ -37,19 +37,19 @@
   <li><a href="/artist/grid">Multiple Level Grid</a></li>
 </ul>
 
-<h2>Bootstrap 3 Support</h2>
+<h2>Bootstrap 5 Support</h2>
 
-<p>Forme now supports <a href="http://getbootstrap.com/">Bootstrap 3</a> Form output.</p>
+<p>Forme now supports <a href="http://getbootstrap.com/">Bootstrap 5</a> Form output.</p>
 
 <ul>
-  <li><a href="/bs3/album/basic/default">Bootstrap 3 - Defaults</a></li>
-  <li><a href="/bs3/album/basic/alt_assoc">Bootstrap 3 - Association Radio and Checkboxes</a></li>
-  <li><a href="/bs3/album/basic/table">Bootstrap 3 - Table</a></li>
-  <li><a href="/bs3/album/basic/list">Bootstrap 3 - List</a></li>
-  <li><a href="/bs3/album/basic/date">Bootstrap 3 - Date Multiple Select Boxes</a></li>
-  <li><a href="/bs3/album/basic/readonly">Bootstrap 3 - Read Only</a></li>
-  <li><a href="/bs3/album/nested">Bootstrap 3 - Single Level Nesting</a></li>
-  <li><a href="/bs3/artist/nested">Bootstrap 3 - Multiple Level Nesting</a></li>
+  <li><a href="/bs5/album/basic/default">Bootstrap 5 - Defaults</a></li>
+  <li><a href="/bs5/album/basic/alt_assoc">Bootstrap 5 - Association Radio and Checkboxes</a></li>
+  <li><a href="/bs5/album/basic/table">Bootstrap 5 - Table</a></li>
+  <li><a href="/bs5/album/basic/list">Bootstrap 5 - List</a></li>
+  <li><a href="/bs5/album/basic/date">Bootstrap 5 - Date Multiple Select Boxes</a></li>
+  <li><a href="/bs5/album/basic/readonly">Bootstrap 5 - Read Only</a></li>
+  <li><a href="/bs5/album/nested">Bootstrap 5 - Single Level Nesting</a></li>
+  <li><a href="/bs5/artist/nested">Bootstrap 5 - Multiple Level Nesting</a></li>
 </ul>
 
 <p>Raise an <a href="http://github.com/jeremyevans/forme/issues">issue</a> if anything is wrong or missing in this support.</p>
@@ -59,7 +59,7 @@
 
 <p>All examples use the same database schema, created by this Sequel code:</p>
 
-<pre><code><%= File.read(CREATE_TABLES_FILE) %></code></pre>
+<pre class="border border-secondary bg-light rounded p-3"><code><%= File.read(CREATE_TABLES_FILE) %></code></pre>
 
 <p>This demo site is part of the Forme repository, so if you want to know how it works, you can <a href="https://github.com/jeremyevans/forme/tree/master/demo-site">review the source</a>.</p>
 

--- a/demo-site/views/layout.erb
+++ b/demo-site/views/layout.erb
@@ -7,63 +7,57 @@
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>Forme Demo - <%= @page_title %></title>
     
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="/css/forme_demo.css" />
-    <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
   </head>
   
   <body>
     
-    <nav class="navbar navbar-inverse navbar-fixed-top">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
       <div class="container">
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="/">Forme Demo</a>
-        </div>
+        <a class="navbar-brand" href="/">Forme Demo</a>
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#navbar" aria-expanded="false" aria-controls="navbar" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
         <div id="navbar" class="navbar-collapse collapse">
-          <ul class="nav navbar-nav">
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Defaults <span class="caret"></span></a>
+          <ul class="navbar-nav">
+            <li class="nav-item dropdown">
+              <a href="#" class="nav-link active dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Defaults</a>
               <ul class="dropdown-menu">
-                <li><a href="/album/basic/default">Default</a></li>
-                <li><a href="/album/basic/explicit">Explicit</a></li>
-                <li><a href="/album/basic/table">Table</a></li>
-                <li><a href="/album/basic/list">List</a></li>
-                <li><a href="/album/basic/date">Date</a></li>
-                <li><a href="/album/basic/alt_assoc">Association</a></li>
-                <li><a href="/album/basic/readonly">Read Only</a></li>
-                <li><a href="/album/basic/text">Text</a></li>
-                <li role="separator" class="divider"></li>
-                <li><a href="/album/nested">Nested 1</a></li>
-                <li><a href="/artist/nested">Nested 2</a></li>
-                <li role="separator" class="divider"></li>
-                <li><a href="/album/grid">Grid 1</a></li>
-                <li><a href="/artist/grid">Grid 2</a></li>
+                <li><a class="dropdown-item" href="/album/basic/default">Default</a></li>
+                <li><a class="dropdown-item" href="/album/basic/explicit">Explicit</a></li>
+                <li><a class="dropdown-item" href="/album/basic/table">Table</a></li>
+                <li><a class="dropdown-item" href="/album/basic/list">List</a></li>
+                <li><a class="dropdown-item" href="/album/basic/date">Date</a></li>
+                <li><a class="dropdown-item" href="/album/basic/alt_assoc">Association</a></li>
+                <li><a class="dropdown-item" href="/album/basic/readonly">Read Only</a></li>
+                <li><a class="dropdown-item" href="/album/basic/text">Text</a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" href="/album/nested">Nested 1</a></li>
+                <li><a class="dropdown-item" href="/artist/nested">Nested 2</a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" href="/album/grid">Grid 1</a></li>
+                <li><a class="dropdown-item" href="/artist/grid">Grid 2</a></li>
               </ul>
             </li>
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Bootstrap 3 <span class="caret"></span></a>
+            <li class="nav-item dropdown">
+              <a href="#" class="nav-link active dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Bootstrap 5</a>
               <ul class="dropdown-menu">
-                <li><a href="/bs3/album/basic/default">Defaults</a></li>
-                <li><a href="/bs3/album/basic/alt_assoc">Association</a></li>
-                <li><a href="/bs3/album/basic/readonly">Read Only</a></li>
-                <li><a href="/bs3/album/basic/table">Table</a></li>
-                <li><a href="/bs3/album/basic/list">List</a></li>
-                <li><a href="/bs3/album/basic/date">Date</a></li>
-                <li role="separator" class="divider"></li>
-                <li><a href="/bs3/album/nested">Nested 1</a></li>
-                <li><a href="/bs3/artist/nested">Nested 2</a></li>
+                <li><a class="dropdown-item" href="/bs5/album/basic/default">Defaults</a></li>
+                <li><a class="dropdown-item" href="/bs5/album/basic/alt_assoc">Association</a></li>
+                <li><a class="dropdown-item" href="/bs5/album/basic/readonly">Read Only</a></li>
+                <li><a class="dropdown-item" href="/bs5/album/basic/table">Table</a></li>
+                <li><a class="dropdown-item" href="/bs5/album/basic/list">List</a></li>
+                <li><a class="dropdown-item" href="/bs5/album/basic/date">Date</a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" href="/bs5/album/nested">Nested 1</a></li>
+                <li><a class="dropdown-item" href="/bs5/artist/nested">Nested 2</a></li>
               </ul>
             </li>
-            <li><a href="http://github.com/jeremyevans/forme">Code</a></li>
-            <li><a href="http://github.com/jeremyevans/forme/issues">Issues</a></li>
-            <li><a href="https://github.com/jeremyevans/forme/discussions">Forum</a></li>
+            <li class="nav-item"><a class="nav-link active" href="http://github.com/jeremyevans/forme" target="_blank">Code</a></li>
+            <li class="nav-item"><a class="nav-link active" href="http://github.com/jeremyevans/forme/issues" target="_blank">Issues</a></li>
+            <li class="nav-item"><a class="nav-link active" href="https://github.com/jeremyevans/forme/discussions" target="_blank">Forum</a></li>
           </ul>
           
         </div><!--/.navbar-collapse -->
@@ -92,7 +86,7 @@
           
           <% if @templ %>
             <h2>Settings</h2>
-<pre>
+<pre class="border border-secondary bg-light rounded p-3">
 form_attr = <%= form_attr.inspect %>
 form_opts = <%= form_opts.inspect %><%= "\nsubform_opts = #{subform_opts.inspect}" if @subform_opts %>
 </pre>
@@ -100,11 +94,11 @@ form_opts = <%= form_opts.inspect %><%= "\nsubform_opts = #{subform_opts.inspect
               <% if @css %>
               <style type="text/css"><%= @css %></style>
               <h2>Custom CSS</h2>
-              <pre><%= @css %></pre>
+              <pre class="border border-secondary bg-light rounded p-3"><%= @css %></pre>
               <% end %>
           
             <h2>Template Code</h2>
-            <pre><%=h File.read(File.expand_path("../#{@templ}.erb", __FILE__)) %></pre>
+            <pre class="border border-secondary bg-light rounded p-3"><%=h File.read(File.expand_path("../#{@templ}.erb", __FILE__)) %></pre>
          <% end %>
         </div>
       </div>

--- a/lib/forme/bs5.rb
+++ b/lib/forme/bs5.rb
@@ -1,0 +1,205 @@
+# frozen-string-literal: true
+
+module Forme
+  register_config(:bs5, formatter: :bs5, wrapper: :bs5, error_handler: :bs5, serializer: :bs5, labeler: :bs5, helper: :bs5, tag_wrapper: :bs5, set_wrapper: :div)
+
+  class ErrorHandler::Bootstrap5
+    Forme.register_transformer(:error_handler, :bs5, new)
+
+    def call(tags, input)
+      attr = input.opts[:error_attr]
+      attr = attr ? attr.dup : {}
+
+      unless attr[:class] && attr[:class].include?("invalid-tooltip")
+        Forme.attr_classes(attr, "invalid-feedback")
+      end
+
+      attr[:id] ||= input.opts[:error_id]
+
+      [tags, input.tag(:div, attr, input.opts[:error])]
+    end
+  end
+
+  class Formatter::Bootstrap5 < Formatter
+    Forme.register_transformer(:formatter, :bs5, self)
+
+    private
+
+    def normalize_options
+      super
+
+      if @opts[:error]
+        # remove "error" class
+        @attr[:class] = @attr[:class].to_s.sub(/\s*error$/,'')
+        @attr.delete(:class) if @attr[:class].to_s == ''
+
+        Forme.attr_classes(@attr, "is-invalid")
+      end
+
+      if @opts[:help]
+        if @opts[:helper_attr] && @opts[:helper_attr][:id]
+          @attr["aria-describedby"] ||= @opts[:helper_attr][:id]
+        end
+      end
+    end
+  end
+
+  # Formatter that adds "readonly" for most input types,
+  # and disables select/radio/checkbox inputs.
+  #
+  # Registered as :bs5_readonly.
+  class Formatter::Bs5ReadOnly < Formatter
+    Forme.register_transformer(:formatter, :bs5_readonly, self)
+
+    private
+
+    # Disabled checkbox inputs.
+    def format_checkbox
+      @attr[:disabled] = :disabled
+      super
+    end
+
+    # Use a span with text instead of an input field.
+    def _format_input(type)
+      @attr[:readonly] = :readonly
+      super
+    end
+
+    # Disabled radio button inputs.
+    def format_radio
+      @attr[:disabled] = :disabled
+      super
+    end
+
+    # Use a span with text of the selected values instead of a select box.
+    def format_select
+      @attr[:disabled] = :disabled
+      super
+    end
+
+    # Use a span with text instead of a text area.
+    def format_textarea
+      @attr[:readonly] = :readonly
+      super
+    end
+  end
+
+  # Use a <table class="table"> tag to wrap the inputs.
+  #
+  # Registered as :bs5_table.
+  class InputsWrapper::Bs5Table
+    Forme.register_transformer(:inputs_wrapper, :bs5_table, new)
+
+    # Wrap the inputs in a <table> tag.
+    def call(form, opts, &block)
+      attr = opts[:attr] ? opts[:attr].dup : { :class=>'table table-bordered'}
+      form.tag(:table, attr) do
+        if legend = opts[:legend]
+          form.tag(:caption, opts[:legend_attr], legend)
+        end
+
+        if (labels = opts[:labels]) && !labels.empty?
+          form.tag(:tr, {}, labels.map{|l| form._tag(:th, {}, l)})
+        end
+
+        yield
+      end
+    end
+  end
+
+  class Labeler::Bootstrap5 < Labeler::Explicit
+    Forme.register_transformer(:labeler, :bs5, new)
+
+    def call(tag, input)
+      floating_label = (input.opts[:wrapper_attr] || {})[:class].to_s.include?("form-floating")
+      input.opts[:label_position] ||= :after if floating_label
+
+      tags = super
+      return tags if floating_label
+
+      attr = tags.find { |tag| tag.is_a?(Tag) && tag.type == :label }.attr
+
+      case input.type
+      when :radio, :checkbox
+        attr[:class] = Forme.merge_classes("form-check-label", attr[:class])
+      else
+        attr[:class] = Forme.merge_classes("form-label", attr[:class])
+      end
+
+      tags
+    end
+  end
+
+  class Helper::Bootstrap5
+    Forme.register_transformer(:helper, :bs5, new)
+
+    def call(tag, input)
+      attr = input.opts[:helper_attr]
+      attr = attr ? attr.dup : {}
+      Forme.attr_classes(attr, 'form-text')
+      [tag, input.tag(:div, attr, input.opts[:help])]
+    end
+  end
+
+  class Wrapper::Bootstrap5 < Wrapper
+    Forme.register_transformer(:wrapper, :bs5, new)
+
+    def call(tag, input)
+      attr = input.opts[:wrapper_attr] ? input.opts[:wrapper_attr].dup : { }
+
+      case input.type
+      when :submit, :reset, :hidden
+        super
+      when :radio, :checkbox
+        attr[:class] = Forme.merge_classes("form-check", attr[:class])
+        input.tag(:div, attr, super)
+      else
+        input.tag(:div, attr, super)
+      end
+    end
+  end
+
+  class Serializer::Bootstrap5 < Serializer
+    Forme.register_transformer(:serializer, :bs5, new)
+
+    BUTTON_STYLES = %w[
+      btn-primary btn-secondary btn-success btn-danger btn-warning btn-info btn-light btn-dark btn-link
+      btn-outline-primary btn-outline-secondary btn-outline-success btn-outline-danger btn-outline-warning btn-outline-info btn-outline-light btn-outline-dark
+    ]
+
+    def call(tag)
+      return super unless tag.is_a?(Tag)
+
+      case tag.type
+      when :input
+        # default to <input type="text"...> if not set
+        tag.attr[:type] = :text if tag.attr[:type].nil?
+
+        case tag.attr[:type].to_sym
+        when :checkbox, :radio
+          tag.attr[:class] = Forme.merge_classes("form-check-input", tag.attr[:class])
+        when :range
+          tag.attr[:class] = Forme.merge_classes("form-range", tag.attr[:class])
+        when :color
+          tag.attr[:class] = Forme.merge_classes("form-control form-control-color", tag.attr[:class])
+        when :submit, :reset
+          classes = ["btn"]
+          classes << "btn-primary" if (tag.attr[:class].to_s.split(" ") & BUTTON_STYLES).empty?
+          tag.attr[:class] = Forme.merge_classes(*classes, tag.attr[:class])
+        when :hidden
+          # nothing
+        else
+          unless tag.attr[:class] && tag.attr[:class].include?("form-control-plaintext")
+            tag.attr[:class] = Forme.merge_classes("form-control", tag.attr[:class])
+          end
+        end
+      when :textarea
+        tag.attr[:class] = Forme.merge_classes("form-control", tag.attr[:class])
+      when :select
+        tag.attr[:class] = Forme.merge_classes("form-select", tag.attr[:class])
+      end
+
+      super
+    end
+  end
+end

--- a/spec/bs5_sequel_plugin_spec.rb
+++ b/spec/bs5_sequel_plugin_spec.rb
@@ -1,0 +1,22 @@
+require_relative 'spec_helper'
+require_relative 'sequel_helper'
+require_relative '../lib/forme/bs5'
+
+describe "Forme Sequel::Model BS5 forms" do
+  before do
+    @ab = Album[1]
+    @b = Forme::Form.new(@ab, config: :bs5)
+    @ac = Album[2]
+    @c = Forme::Form.new(@ac, config: :bs5)
+  end
+
+  it "should use a checkbox for dual-valued boolean fields" do
+    @b.input(:platinum).must_equal '<div class="form-check boolean"><input id="album_platinum_hidden" name="album[platinum]" type="hidden" value="f"/><input class="form-check-input" id="album_platinum" name="album[platinum]" type="checkbox" value="t"/><label class="form-check-label label-after" for="album_platinum">Platinum</label></div>'
+    @c.input(:platinum).must_equal '<div class="form-check boolean"><input id="album_platinum_hidden" name="album[platinum]" type="hidden" value="f"/><input checked="checked" class="form-check-input" id="album_platinum" name="album[platinum]" type="checkbox" value="t"/><label class="form-check-label label-after" for="album_platinum">Platinum</label></div>'
+  end
+
+  it "should use radio buttons for boolean fields if :as=>:radio is used" do
+    @b.input(:platinum, :as=>:radio).must_equal '<div class="boolean"><span class="label">Platinum</span><div class="form-check"><input class="form-check-input" id="album_platinum_yes" name="album[platinum]" type="radio" value="t"/><label class="form-check-label option label-after" for="album_platinum_yes">Yes</label></div><div class="form-check"><input checked="checked" class="form-check-input" id="album_platinum_no" name="album[platinum]" type="radio" value="f"/><label class="form-check-label option label-after" for="album_platinum_no">No</label></div></div>'
+    @c.input(:platinum, :as=>:radio).must_equal '<div class="boolean"><span class="label">Platinum</span><div class="form-check"><input checked="checked" class="form-check-input" id="album_platinum_yes" name="album[platinum]" type="radio" value="t"/><label class="form-check-label option label-after" for="album_platinum_yes">Yes</label></div><div class="form-check"><input class="form-check-input" id="album_platinum_no" name="album[platinum]" type="radio" value="f"/><label class="form-check-label option label-after" for="album_platinum_no">No</label></div></div>'
+  end
+end

--- a/spec/bs5_spec.rb
+++ b/spec/bs5_spec.rb
@@ -1,0 +1,113 @@
+require_relative 'spec_helper'
+require_relative '../lib/forme/bs5'
+
+describe "Forme Bootstrap5 (BS5) forms" do
+  before do
+    @f = Forme::Form.new(config: :bs5)
+  end
+
+  it "should generate email and password fields" do
+    @f.input(:email).must_equal '<div><input class="form-control" type="email"/></div>'
+    @f.input(:email, label: "Email address").must_equal '<div><label class="form-label label-before">Email address</label><input class="form-control" type="email"/></div>'
+    @f.input(:password).must_equal '<div><input class="form-control" type="password"/></div>'
+    @f.input(:password, label: "Password").must_equal '<div><label class="form-label label-before">Password</label><input class="form-control" type="password"/></div>'
+  end
+
+  it "should generate submit buttons" do
+    @f.button("Click me").must_equal '<input class="btn btn-primary" type="submit" value="Click me"/>'
+    @f.button(value: "Click me", class: "btn-warning").must_equal '<input class="btn btn-warning" type="submit" value="Click me"/>'
+    @f.button(value: "Click me", class: "btn-outline-success").must_equal '<input class="btn btn-outline-success" type="submit" value="Click me"/>'
+  end
+
+  it "should generate hidden fields" do
+    @f.input(:hidden, value: "foobar").must_equal '<input type="hidden" value="foobar"/>'
+  end
+
+  it "should generate checkboxes" do
+    @f.input(:checkbox).must_equal '<div class="form-check"><input class="form-check-input" type="checkbox"/></div>'
+    @f.input(:checkbox, label: "Check me out").must_equal '<div class="form-check"><input class="form-check-input" type="checkbox"/><label class="form-check-label label-after">Check me out</label></div>'
+  end
+
+  it "should generate radio buttons" do
+    @f.input(:radio).must_equal '<div class="form-check"><input class="form-check-input" type="radio"/></div>'
+    @f.input(:radio, label: "Default radio").must_equal '<div class="form-check"><input class="form-check-input" type="radio"/><label class="form-check-label label-after">Default radio</label></div>'
+  end
+
+  it "should generate textarea fields" do
+    @f.input(:textarea).must_equal '<div><textarea class="form-control"></textarea></div>'
+  end
+
+  it "should generate select fields" do
+    @f.input(:select, options: { 'Foo' => 'foo', 'Bar' => 'bar' }, selected: 'bar').must_equal '<div><select class="form-select"><option value="foo">Foo</option><option selected="selected" value="bar">Bar</option></select></div>'
+  end
+
+  it "should generate range fields" do
+    @f.input(:range).must_equal '<div><input class="form-range" type="range"/></div>'
+  end
+
+  it "should generate color fields" do
+    @f.input(:color).must_equal '<div><input class="form-control form-control-color" type="color"/></div>'
+  end
+
+  it "should link labels to input fields" do
+    @f.input(:text, label: "Some field", id: "some_field").must_equal '<div><label class="form-label label-before" for="some_field">Some field</label><input class="form-control" id="some_field" type="text"/></div>'
+  end
+
+  it "should generate form text" do
+    @f.input(:text, help: "This is some hint").must_equal '<div><input class="form-control" type="text"/><div class="form-text">This is some hint</div></div>'
+    @f.input(:text, help: "This is some hint", helper_attr: { id: "field_help" }).must_equal '<div><input aria-describedby="field_help" class="form-control" type="text"/><div class="form-text" id="field_help">This is some hint</div></div>'
+    @f.input(:text, label: "Some label", help: "This is some hint").must_equal '<div><label class="form-label label-before">Some label</label><input class="form-control" type="text"/><div class="form-text">This is some hint</div></div>'
+    @f.input(:text, label: "Some label", help: "This is some hint", helper_attr: { id: "field_help" }).must_equal '<div><label class="form-label label-before">Some label</label><input aria-describedby="field_help" class="form-control" type="text"/><div class="form-text" id="field_help">This is some hint</div></div>'
+  end
+
+  it "should generate error feedback" do
+    @f.input(:text, error: "This is wrong").must_equal '<div><input aria-invalid="true" class="form-control is-invalid" type="text"/><div class="invalid-feedback">This is wrong</div></div>'
+    @f.input(:text, error: "This is wrong", error_id: "field_feedback").must_equal '<div><input aria-describedby="field_feedback" aria-invalid="true" class="form-control is-invalid" type="text"/><div class="invalid-feedback" id="field_feedback">This is wrong</div></div>'
+    @f.input(:text, error: "This is wrong", label: "Some label").must_equal '<div><label class="form-label label-before">Some label</label><input aria-invalid="true" class="form-control is-invalid" type="text"/><div class="invalid-feedback">This is wrong</div></div>'
+    @f.input(:text, error: "This is wrong", error_id: "field_feedback", label: "Some label").must_equal '<div><label class="form-label label-before">Some label</label><input aria-describedby="field_feedback" aria-invalid="true" class="form-control is-invalid" type="text"/><div class="invalid-feedback" id="field_feedback">This is wrong</div></div>'
+    @f.input(:text, error: "This is wrong", class: "foo").must_equal '<div><input aria-invalid="true" class="form-control foo is-invalid" type="text"/><div class="invalid-feedback">This is wrong</div></div>'
+  end
+
+  it "should consider form's :errors hash based on the :key option" do
+    @f.opts[:errors] = { "foo" => "must be present" }
+    @f.input(:text, key: "foo").must_equal '<div><input aria-describedby="foo_error_message" aria-invalid="true" class="form-control is-invalid" id="foo" name="foo" type="text"/><div class="invalid-feedback" id="foo_error_message">must be present</div></div>'
+  end
+
+  it "should support error tooltips" do
+    @f.input(:text, error: "This is wrong", error_attr: { class: "invalid-tooltip" }).must_equal '<div><input aria-invalid="true" class="form-control is-invalid" type="text"/><div class="invalid-tooltip">This is wrong</div></div>'
+  end
+
+  it "supports control sizing, select sizing, switches, and inline radios" do
+    @f.input(:text, class: "form-control-lg").must_equal '<div><input class="form-control form-control-lg" type="text"/></div>'
+    @f.input(:select, class: "form-select-lg").must_equal '<div><select class="form-select form-select-lg"></select></div>'
+    @f.input(:checkbox, wrapper_attr: { class: "form-switch" }, attr: { role: "switch" }).must_equal '<div class="form-check form-switch"><input class="form-check-input" role="switch" type="checkbox"/></div>'
+    @f.input(:radio, wrapper_attr: { class: "form-check-inline" }).must_equal '<div class="form-check form-check-inline"><input class="form-check-input" type="radio"/></div>'
+  end
+
+  it "should support floating labels" do
+    @f.input(:text, label: "Some label", id: "some_field", wrapper_attr: { class: "form-floating" }).must_equal '<div class="form-floating"><input class="form-control" id="some_field" type="text"/><label class="label-after" for="some_field">Some label</label></div>'
+  end
+
+  it "should support plaintext fields" do
+    @f.input(:email, class: "form-control-plaintext").must_equal '<div><input class="form-control-plaintext" type="email"/></div>'
+  end
+
+  it "should support readonly formatter" do
+    @f.input(:email, formatter: :bs5_readonly).must_equal '<div><input class="form-control" readonly="readonly" type="email"/></div>'
+    @f.input(:checkbox, formatter: :bs5_readonly).must_equal '<div class="form-check"><input class="form-check-input" disabled="disabled" type="checkbox"/></div>'
+    @f.input(:radio, formatter: :bs5_readonly).must_equal '<div class="form-check"><input class="form-check-input" disabled="disabled" type="radio"/></div>'
+    @f.input(:select, formatter: :bs5_readonly).must_equal '<div><select class="form-select" disabled="disabled"></select></div>'
+    @f.input(:textarea, formatter: :bs5_readonly).must_equal '<div><textarea class="form-control" readonly="readonly"></textarea></div>'
+  end
+
+  it "should support custom inputs wrapper" do
+    @f.inputs([:textarea], inputs_wrapper: :ol).must_equal '<ol><div><textarea class="form-control"></textarea></div></ol>'
+    @f.inputs([:textarea], inputs_wrapper: :bs5_table, wrapper: :trtd).must_equal '<table class="table table-bordered"><tr><td><textarea class="form-control"></textarea></td><td></td></tr></table>'
+    @f.inputs([:textarea], inputs_wrapper: :bs5_table, wrapper: :trtd, legend: 'Foo', labels: ['bar']).must_equal '<table class="table table-bordered"><caption>Foo</caption><tr><th>bar</th></tr><tr><td><textarea class="form-control"></textarea></td><td></td></tr></table>'
+    @f.inputs([:textarea], inputs_wrapper: :bs5_table, wrapper: :trtd, attr: {class: 'foo'}).must_equal '<table class="foo"><tr><td><textarea class="form-control"></textarea></td><td></td></tr></table>'
+  end
+
+  it "should default input type to text" do
+    @f.tag(:input).must_equal '<input class="form-control" type="text"/>'
+  end
+end


### PR DESCRIPTION
It's significantly simpler than the Bootstrap 3 configuration, partly due to changes in Bootstrap 5, partly due to greater code reuse, and partly due to probably not support every use case.

* checkboxes & radio buttons
* labels (supports floating labels)
* text-based fields (supports readonly plain text fields)
* validation errors (supports tooltips)
* primary submit button (supports changing style)
* select boxes
* range and color inputs

```rb
Forme.form @article, { action: "/articles", method: :post } do |f|
  f.input :title, wrapper_attr: { class: "mb-3" }, help: "Make it meaningful"
  f.input :body, as: :textarea, wrapper_attr: { class: "mb-3" }
  f.button value: "Create Article", class: "btn-success"
end
```
```html
<form action="/articles" class="forme article" method="post">
  <div class="mb-3 string required">
    <label class="form-label label-before" for="article_title">Title</label>
    <input class="form-control" id="article_title" maxlength="255" name="article[title]" required="required" type="text"/>
    <div class="form-text">Make it meaningful</div>
  </div>
  <div class="mb-3 string required">
    <label class="form-label label-before" for="article_body">Body</label>
    <textarea class="form-control" id="article_body" maxlength="255" name="article[body]" required="required"/>
  </div>
  <input class="btn btn-success" type="submit" value="Create Article"/>
</form>
```
